### PR TITLE
Remove changelog.md from .vtexignore

### DIFF
--- a/.vtexignore
+++ b/.vtexignore
@@ -6,4 +6,3 @@ src/
 .gitignore
 package.json
 README.md
-CHANGELOG.md


### PR DESCRIPTION
This an [automated pull request](https://github.com/vtex/github-pull-request-script) that aims to:

- Remove CHANGELOG.md from .vtexignore

When approved, feel free to merge it as if it was created by a bot account :robot:.

**#trivial**